### PR TITLE
Support of wildcard in S3ListOperator and S3ToGCSOperator (b/245074128)

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3.py
+++ b/airflow/providers/amazon/aws/operators/s3.py
@@ -683,7 +683,12 @@ class S3ListOperator(BaseOperator):
             self.delimiter,
         )
 
-        return hook.list_keys(bucket_name=self.bucket, prefix=self.prefix, delimiter=self.delimiter)
+        return hook.list_keys(
+            bucket_name=self.bucket,
+            prefix=self.prefix,
+            delimiter=self.delimiter,
+            apply_wildcard=True,
+        )
 
 
 class S3ListPrefixesOperator(BaseOperator):

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -221,6 +221,7 @@ class TestAwsS3Hook:
         hook = S3Hook()
         bucket = hook.get_bucket(s3_bucket)
         bucket.put_object(Key="a", Body=b"a")
+        bucket.put_object(Key="ba", Body=b"ab")
         bucket.put_object(Key="dir/b", Body=b"b")
 
         from_datetime = datetime(1992, 3, 8, 18, 52, 51)
@@ -230,14 +231,16 @@ class TestAwsS3Hook:
             return []
 
         assert [] == hook.list_keys(s3_bucket, prefix="non-existent/")
-        assert ["a", "dir/b"] == hook.list_keys(s3_bucket)
-        assert ["a"] == hook.list_keys(s3_bucket, delimiter="/")
+        assert ["a", "ba", "dir/b"] == hook.list_keys(s3_bucket)
+        assert ["a", "ba"] == hook.list_keys(s3_bucket, delimiter="/")
         assert ["dir/b"] == hook.list_keys(s3_bucket, prefix="dir/")
-        assert ["dir/b"] == hook.list_keys(s3_bucket, start_after_key="a")
+        assert ["ba", "dir/b"] == hook.list_keys(s3_bucket, start_after_key="a")
         assert [] == hook.list_keys(s3_bucket, from_datetime=from_datetime, to_datetime=to_datetime)
         assert [] == hook.list_keys(
             s3_bucket, from_datetime=from_datetime, to_datetime=to_datetime, object_filter=dummy_object_filter
         )
+        assert [] == hook.list_keys(s3_bucket, prefix="*a")
+        assert ["a", "ba"] == hook.list_keys(s3_bucket, prefix="*a", apply_wildcard=True)
 
     def test_list_keys_paged(self, s3_bucket):
         hook = S3Hook()

--- a/tests/providers/amazon/aws/operators/test_s3_list.py
+++ b/tests/providers/amazon/aws/operators/test_s3_list.py
@@ -39,6 +39,6 @@ class TestS3ListOperator:
         files = operator.execute(None)
 
         mock_hook.return_value.list_keys.assert_called_once_with(
-            bucket_name=BUCKET, prefix=PREFIX, delimiter=DELIMITER
+            bucket_name=BUCKET, prefix=PREFIX, delimiter=DELIMITER, apply_wildcard=True
         )
         assert sorted(files) == sorted(MOCK_FILES)


### PR DESCRIPTION
Add support of wildcard in a prefix for `S3ListOperator` and `S3ToGCSOperator`.

Other operators using `S3Hook` behave with no change as long as they are calling method `S3Hook.list_keys()` without specifying parameter `apply_wildcard=True`.