### PR TITLE
Bugfix for GCSToGCSOperator (b/289486604)

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -370,6 +370,9 @@ class GCSToGCSOperator(BaseOperator):
             self.source_bucket, prefix=prefix, delimiter=self.delimiter, match_glob=self.match_glob
         )
 
+        if self.exact_match:
+            objects = [obj for obj in objects if self._check_exact_match(obj, prefix)]
+
         if not self.replace:
             # If we are not replacing, ignore files already existing in source buckets
             objects = self._ignore_existing_files(
@@ -405,7 +408,7 @@ class GCSToGCSOperator(BaseOperator):
     def _copy_directory(self, hook, source_objects, prefix):
         _prefix = prefix.rstrip("/") + "/"
         for source_obj in source_objects:
-            if self.exact_match and (source_obj != prefix or not source_obj.endswith(prefix)):
+            if not self._check_exact_match(source_obj, prefix):
                 continue
             if self.destination_object is None:
                 destination_object = source_obj
@@ -416,6 +419,12 @@ class GCSToGCSOperator(BaseOperator):
             self._copy_single_object(
                 hook=hook, source_object=source_obj, destination_object=destination_object
             )
+
+    def _check_exact_match(self, source_object: str, prefix: str) -> bool:
+        """Checks whether source_object's name matches the prefix according to the exact_match flag."""
+        if self.exact_match and (source_object != prefix or not source_object.endswith(prefix)):
+            return False
+        return True
 
     def _copy_source_with_wildcard(self, hook, prefix):
         total_wildcards = prefix.count(WILDCARD)


### PR DESCRIPTION
Bugfix for the following case (b/289486604).

The goal is to copy `source/foo.txt` to `dest/foo.txt` within a single GCS bucket.
1. Create a GCS bucket and upload two files to source directory like this:
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
```
2. Upload the following DAG to a Cloud Composer environment:
```python
from airflow import DAG
from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
from datetime import datetime

with DAG(
    dag_id="gcs_to_gcs_fail_example",
    schedule_interval=None,
    catchup=False,
    start_date=datetime(2021,1,1)
) as dag:
    copy_file = GCSToGCSOperator(
        task_id="copy_file",
        source_bucket="my-bucket",
        source_object="source/foo.txt",
        destination_object="dest/foo.txt",
        exact_match=True,
    )
    copy_file
```
3. Run the DAG

**Expected bucket state:**
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
gs://my-bucket/dest/foo.txt
```
**Actual (incorrect) bucket state:**
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
gs://my-bucket/dest/foo.txt/source/foo.txt
```

======================================================

The reason for this bug was the lack of handling `exact_match=True` when objects are being copied without a wildcard. This problem is fixed in the current PR.

======================================================

However, if the flag is set to its default value `exact_match=False`, then the operator's result is different:
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
gs://my-bucket/dest/foo.txt/source/foo.txt
gs://my-bucket/dest/foo.txt/source/foo.txt.abc
```
It's actually correct, because in general `source_object="path/to/the/file.txt"` is not treated as a file path, but as an object name **prefix** ([doc](https://cloud.google.com/storage/docs/samples/storage-list-files-with-prefix)). That's why the **prefix** `source_object="path/to/the/file.txt"` corresponds to both objects:
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
```
And if the destination_object is set, then the destination object prefix is just built as a concatenation of the source prefix and the destination prefix. There is no difference for GCS what is being copied: a file or a folder - both of these entities are the same things - objects.

Perhaps, it makes sense to implement more "human friendly" logic, so the operator would act with inputs as with files and folders, but I think it should be another operator, because `GCSToGCSOperator`'s current implementation became too complicated for major changes. This is just my thoughts, I'm not insisting.