### PR TITLE
Bugfix GCSToGCSOperator when copy files to folder without wildcard

### DIFF
--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
@@ -97,6 +97,9 @@ Copy single file
 ----------------
 
 The following example would copy a single file, ``OBJECT_1`` from the ``BUCKET_1_SRC`` GCS bucket to the ``BUCKET_1_DST`` bucket.
+Note that if the flag ``exact_match=False`` then the ``source_object`` will be considered as a prefix for search objects
+in the ``BUCKET_1_SRC`` GCS bucket. That's why if any will be found, they will be copied as well. To prevent this from
+happening, please use ``exact_match=False``.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
     :language: python
@@ -165,6 +168,9 @@ Move single file
 ----------------
 
 Supplying ``True`` to the ``move`` argument causes the operator to delete ``source_object`` once the copy is complete.
+Note that if the flag ``exact_match=False`` then the ``source_object`` will be considered as a prefix for search objects
+in the ``BUCKET_1_SRC`` GCS bucket. That's why if any will be found, they will be copied as well. To prevent this from
+happening, please use ``exact_match=False``.
 
 .. exampleinclude:: /../../tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
     :language: python

--- a/tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_gcs_to_gcs.py
@@ -139,6 +139,7 @@ with models.DAG(
         source_object=OBJECT_1,
         destination_bucket=BUCKET_NAME_DST,  # If not supplied the source_bucket value will be used
         destination_object="backup_" + OBJECT_1,  # If not supplied the source_object value will be used
+        exact_match=True,
     )
     # [END howto_operator_gcs_to_gcs_single_file]
 
@@ -201,6 +202,7 @@ with models.DAG(
         source_object=OBJECT_1,
         destination_bucket=BUCKET_NAME_DST,
         destination_object="backup_" + OBJECT_1,
+        exact_match=True,
         move_object=True,
     )
     # [END howto_operator_gcs_to_gcs_single_file_move]


### PR DESCRIPTION
This PR fixes the following case.

The goal is to copy files with prefix `source/foo.txt` to the folder `dest/` within a single GCS bucket.
1. Create a GCS bucket and upload two files to source directory like this:
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
gs://my-bucket/source/foo.txt/subfolder/file.txt
```
2. Upload the following DAG to a Cloud Composer environment:
```python
from airflow import DAG
from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
from datetime import datetime

with DAG(
    dag_id="gcs_to_gcs_fail_example",
    schedule_interval=None,
    catchup=False,
    start_date=datetime(2021,1,1)
) as dag:
    copy_file = GCSToGCSOperator(
        task_id="copy_file",
        source_bucket="my-bucket",
        source_object="source/foo.txt",
        destination_object="dest/",
    )
    copy_file
```
3. Run the DAG

**Expected bucket state:**
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
gs://my-bucket/source/foo.txt/subfolder/file.txt
gs://my-bucket/dest/foo.txt
gs://my-bucket/dest/foo.txt.abc
gs://my-bucket/dest/foo.txt/subfolder/file.txt
```
**Actual (incorrect) bucket state:**
```
gs://my-bucket/source/foo.txt
gs://my-bucket/source/foo.txt.abc
gs://my-bucket/source/foo.txt/subfolder/file.txt
gs://my-bucket/dest/source/foo.txt
gs://my-bucket/dest/source/foo.txt.abc
gs://my-bucket/dest/source/foo.txt/subfolder/file.txt
```