### PR TITLE
Fixup system test for DataprocSubmitJobOperator (Spark job)

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1355,6 +1355,10 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
 class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
     """Start a Spark Job on a Cloud DataProc cluster.
 
+    .. seealso::
+        This operator is deprecated, please use
+        :class:`~airflow.providers.google.cloud.operators.dataproc.DataprocSubmitJobOperator`:
+
     :param main_jar: The HCFS URI of the jar file that contains the main class
         (use this or the main_class, not both together).
     :param main_class: Name of the job class. (use this or the main_jar, not both

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark.py
@@ -39,7 +39,6 @@ CLUSTER_NAME = f"cluster-dataproc-spark-{ENV_ID}"
 REGION = "europe-west1"
 ZONE = "europe-west1-b"
 
-
 # Cluster definition
 CLUSTER_CONFIG = {
     "master_config": {
@@ -53,8 +52,6 @@ CLUSTER_CONFIG = {
         "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
     },
 }
-
-TIMEOUT = {"seconds": 1 * 24 * 60 * 60}
 
 # Jobs definitions
 # [START how_to_cloud_dataproc_spark_config]
@@ -74,7 +71,7 @@ with models.DAG(
     schedule="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    tags=["example", "dataproc"],
+    tags=["example", "dataproc", "spark"],
 ) as dag:
     create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster",
@@ -96,7 +93,14 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    create_cluster >> spark_task >> delete_cluster
+    (
+        # TEST SETUP
+        create_cluster
+        # TEST BODY
+        >> spark_task
+        # TEST TEARDOWN
+        >> delete_cluster
+    )
 
     from tests.system.utils.watcher import watcher
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_async.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_async.py
@@ -38,7 +38,6 @@ PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
 
 CLUSTER_NAME = f"dataproc-spark-async-{ENV_ID}"
 REGION = "europe-west1"
-ZONE = "europe-west1-b"
 
 # Cluster definition
 CLUSTER_CONFIG = {
@@ -53,8 +52,6 @@ CLUSTER_CONFIG = {
         "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
     },
 }
-
-TIMEOUT = {"seconds": 1 * 24 * 60 * 60}
 
 # Jobs definitions
 SPARK_JOB = {
@@ -72,7 +69,7 @@ with models.DAG(
     schedule="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    tags=["example", "dataproc"],
+    tags=["example", "dataproc", "spark", "async"],
 ) as dag:
     create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster",
@@ -104,7 +101,15 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    create_cluster >> spark_task_async >> spark_task_async_sensor >> delete_cluster
+    (
+        # TEST SETUP
+        create_cluster
+        # TEST BODY
+        >> spark_task_async
+        >> spark_task_async_sensor
+        # TEST TEARDOWN
+        >> delete_cluster
+    )
 
     from tests.system.utils.watcher import watcher
 

--- a/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_deferrable.py
+++ b/tests/system/providers/google/cloud/dataproc/example_dataproc_spark_deferrable.py
@@ -38,8 +38,6 @@ PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
 
 CLUSTER_NAME = f"cluster-dataproc-spark-{ENV_ID}"
 REGION = "europe-west1"
-ZONE = "europe-west1-b"
-
 
 # Cluster definition
 CLUSTER_CONFIG = {
@@ -54,8 +52,6 @@ CLUSTER_CONFIG = {
         "disk_config": {"boot_disk_type": "pd-standard", "boot_disk_size_gb": 1024},
     },
 }
-
-TIMEOUT = {"seconds": 1 * 24 * 60 * 60}
 
 # Jobs definitions
 # [START how_to_cloud_dataproc_spark_deferrable_config]
@@ -75,7 +71,7 @@ with models.DAG(
     schedule_interval="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    tags=["example", "dataproc"],
+    tags=["example", "dataproc", "spark", "deferrable"],
 ) as dag:
     create_cluster = DataprocCreateClusterOperator(
         task_id="create_cluster",
@@ -97,7 +93,14 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
-    create_cluster >> spark_task >> delete_cluster
+    (
+        # TEST SETUP
+        create_cluster
+        # TEST BODY
+        >> spark_task
+        # TEST TEARDOWN
+        >> delete_cluster
+    )
 
     from tests.system.utils.watcher import watcher
 


### PR DESCRIPTION
Fix for system test for `DataprocSubmitJobOperator` (Spark job):
1. Refactored system tests (AIP-47).
2. Update docstrings for generating more explicit documentation with a deprecation message in `DataprocSubmitSpakJobOperator` and link to the new class `DataprocSubmitJobOperator`.