### PR TITLE
Fix system tests for PostgresToGCSOperator and MySQLToGCSOperator

### DIFF
--- a/tests/system/providers/google/cloud/gcs/example_mysql_to_gcs.py
+++ b/tests/system/providers/google/cloud/gcs/example_mysql_to_gcs.py
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -14,61 +15,274 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""
+Example DAG using MySQLToGCSOperator.
+
+This DAG relies on the following OS environment variables
+
+* AIRFLOW__API__GOOGLE_KEY_PATH - Path to service account key file. Note, you can skip this variable if you
+  run this DAG in a Composer environment.
+"""
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime
 
 import pytest
 
 from airflow import models
-from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator, GCSDeleteBucketOperator
+from airflow.decorators import task
+from airflow.models import Connection
+from airflow.operators.bash import BashOperator
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+from airflow.providers.google.cloud.hooks.compute import ComputeEngineHook
+from airflow.providers.google.cloud.hooks.compute_ssh import ComputeEngineSSHHook
+from airflow.providers.google.cloud.operators.compute import (
+    ComputeEngineDeleteInstanceOperator,
+    ComputeEngineInsertInstanceOperator,
+)
+from airflow.providers.google.cloud.operators.gcs import (
+    GCSCreateBucketOperator,
+    GCSDeleteBucketOperator,
+)
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.settings import Session
+from airflow.utils.trigger_rule import TriggerRule
 
 try:
     from airflow.providers.google.cloud.transfers.mysql_to_gcs import MySQLToGCSOperator
 except ImportError:
     pytest.skip("MySQL not available", allow_module_level=True)
 
-from airflow.utils.trigger_rule import TriggerRule
-
-ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
-PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT")
 DAG_ID = "example_mysql_to_gcs"
+ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
+PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "example-project")
+
+REGION = "europe-west2"
+ZONE = REGION + "-a"
+NETWORK = "default"
+
+DB_NAME = "testdb"
+DB_PORT = 3306
+DB_USER_NAME = "root"
+DB_USER_PASSWORD = "demo_password"
+
+SHORT_MACHINE_TYPE_NAME = "n1-standard-1"
+DB_INSTANCE_NAME = f"instance-{DAG_ID}-{ENV_ID}".replace("_", "-")
+GCE_INSTANCE_BODY = {
+    "name": DB_INSTANCE_NAME,
+    "machine_type": f"zones/{ZONE}/machineTypes/{SHORT_MACHINE_TYPE_NAME}",
+    "disks": [
+        {
+            "boot": True,
+            "device_name": DB_INSTANCE_NAME,
+            "initialize_params": {
+                "disk_size_gb": "10",
+                "disk_type": f"zones/{ZONE}/diskTypes/pd-balanced",
+                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+            },
+        }
+    ],
+    "network_interfaces": [
+        {
+            "access_configs": [{"name": "External NAT", "network_tier": "PREMIUM"}],
+            "stack_type": "IPV4_ONLY",
+            "subnetwork": f"regions/{REGION}/subnetworks/default",
+        }
+    ],
+}
+DELETE_PERSISTENT_DISK = f"""
+if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
+ gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
+fi;
+
+gcloud compute disks delete {DB_INSTANCE_NAME} --project={PROJECT_ID} --zone={ZONE} --quiet
+"""
+
+SETUP_MYSQL = f"""
+sudo apt update &&
+sudo apt install -y docker.io &&
+sudo docker run -d -p {DB_PORT}:{DB_PORT} --name {DB_NAME} \
+    -e MYSQL_ROOT_PASSWORD={DB_USER_PASSWORD} \
+    -e MYSQL_DATABASE={DB_NAME} \
+    mysql:8.1.0
+"""
+
+FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}"
+CREATE_FIREWALL_RULE = f"""
+if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
+ gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
+fi;
+
+gcloud compute firewall-rules create {FIREWALL_RULE_NAME} \
+  --project={PROJECT_ID} \
+  --direction=INGRESS \
+  --priority=100 \
+  --network={NETWORK} \
+  --action=ALLOW \
+  --rules=tcp:{DB_PORT} \
+  --source-ranges=0.0.0.0/0
+"""
+DELETE_FIREWALL_RULE = f"""
+if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
+ gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
+fi;
+
+gcloud compute firewall-rules delete {FIREWALL_RULE_NAME} --project={PROJECT_ID} --quiet
+"""
+
+CONNECTION_ID = f"mysql_{DAG_ID}_{ENV_ID}".replace("-", "_")
 
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
-FILENAME = "test_file"
+FILE_NAME = "result.json"
 
-SQL_QUERY = "SELECT * from test_table"
+SQL_TABLE = "test_table"
+SQL_CREATE = f"CREATE TABLE IF NOT EXISTS {SQL_TABLE} (col_1 INT, col_2 VARCHAR(8))"
+SQL_INSERT = f"INSERT INTO {SQL_TABLE} (col_1, col_2) VALUES (1, 'one'), (2, 'two')"
+SQL_SELECT = f"SELECT * FROM {SQL_TABLE}"
+
+
+log = logging.getLogger(__name__)
+
 
 with models.DAG(
-    DAG_ID,
+    dag_id=DAG_ID,
     schedule="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    tags=["example", "mysql"],
+    tags=["example", "mysql", "gcs"],
 ) as dag:
+    create_instance = ComputeEngineInsertInstanceOperator(
+        task_id="create_instance",
+        project_id=PROJECT_ID,
+        zone=ZONE,
+        body=GCE_INSTANCE_BODY,
+    )
+
+    create_firewall_rule = BashOperator(
+        task_id="create_firewall_rule",
+        bash_command=CREATE_FIREWALL_RULE,
+    )
+
+    setup_mysql = SSHOperator(
+        task_id="setup_mysql",
+        ssh_hook=ComputeEngineSSHHook(
+            user="username",
+            instance_name=DB_INSTANCE_NAME,
+            zone=ZONE,
+            project_id=PROJECT_ID,
+            use_oslogin=False,
+            use_iap_tunnel=False,
+            cmd_timeout=180,
+        ),
+        command=SETUP_MYSQL,
+        retries=2,
+    )
+
+    @task
+    def get_public_ip() -> str:
+        hook = ComputeEngineHook()
+        address = hook.get_instance_address(resource_id=DB_INSTANCE_NAME, zone=ZONE, project_id=PROJECT_ID)
+        return address
+
+    get_public_ip_task = get_public_ip()
+
+    @task
+    def setup_mysql_connection(**kwargs) -> None:
+        public_ip = kwargs["ti"].xcom_pull(task_ids="get_public_ip")
+        connection = Connection(
+            conn_id=CONNECTION_ID,
+            description="Example MySQL connection",
+            conn_type="mysql",
+            host=public_ip,
+            login=DB_USER_NAME,
+            password=DB_USER_PASSWORD,
+            schema=DB_NAME,
+        )
+        session: Session = Session()
+        if session.query(Connection).filter(Connection.conn_id == CONNECTION_ID).first():
+            log.warning("Connection %s already exists", CONNECTION_ID)
+            return None
+
+        session.add(connection)
+        session.commit()
+
+    setup_mysql_connection_task = setup_mysql_connection()
+
     create_bucket = GCSCreateBucketOperator(
-        task_id="create_bucket", bucket_name=BUCKET_NAME, project_id=PROJECT_ID
+        task_id="create_bucket",
+        bucket_name=BUCKET_NAME,
+    )
+
+    create_sql_table = SQLExecuteQueryOperator(
+        task_id="create_sql_table",
+        conn_id=CONNECTION_ID,
+        sql=SQL_CREATE,
+    )
+
+    insert_data = SQLExecuteQueryOperator(
+        task_id="insert_data",
+        conn_id=CONNECTION_ID,
+        sql=SQL_INSERT,
     )
 
     # [START howto_operator_mysql_to_gcs]
     upload_mysql_to_gcs = MySQLToGCSOperator(
-        task_id="mysql_to_gcs", sql=SQL_QUERY, bucket=BUCKET_NAME, filename=FILENAME, export_format="csv"
+        task_id="mysql_to_gcs", sql=SQL_SELECT, bucket=BUCKET_NAME, filename=FILE_NAME, export_format="csv"
     )
     # [END howto_operator_mysql_to_gcs]
 
+    delete_mysql_connection = BashOperator(
+        task_id="delete_mysql_connection",
+        bash_command=f"airflow connections delete {CONNECTION_ID}",
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
     delete_bucket = GCSDeleteBucketOperator(
-        task_id="delete_bucket", bucket_name=BUCKET_NAME, trigger_rule=TriggerRule.ALL_DONE
+        task_id="delete_bucket",
+        bucket_name=BUCKET_NAME,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_instance = ComputeEngineDeleteInstanceOperator(
+        task_id="delete_instance",
+        resource_id=DB_INSTANCE_NAME,
+        zone=ZONE,
+        project_id=PROJECT_ID,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_firewall_rule = BashOperator(
+        task_id="delete_firewall_rule",
+        bash_command=DELETE_FIREWALL_RULE,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_persistent_disk = BashOperator(
+        task_id="delete_persistent_disk",
+        bash_command=DELETE_PERSISTENT_DISK,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     (
         # TEST SETUP
-        create_bucket
+        create_instance
+        >> setup_mysql
+        >> get_public_ip_task
+        >> setup_mysql_connection_task
+        >> create_firewall_rule
+        >> create_sql_table
+        >> insert_data
+    )
+    (
+        [insert_data, create_bucket]
         # TEST BODY
         >> upload_mysql_to_gcs
         # TEST TEARDOWN
-        >> delete_bucket
+        >> [delete_instance, delete_bucket, delete_mysql_connection, delete_firewall_rule]
     )
+    delete_instance >> delete_persistent_disk
 
     from tests.system.utils.watcher import watcher
 

--- a/tests/system/providers/google/cloud/transfers/example_postgres_to_gcs.py
+++ b/tests/system/providers/google/cloud/transfers/example_postgres_to_gcs.py
@@ -16,7 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Example DAG using PostgresToGoogleCloudStorageOperator.
+Example DAG using PostgresToGCSOperator.
+
+This DAG relies on the following OS environment variables
+
+* AIRFLOW__API__GOOGLE_KEY_PATH - Path to service account key file. Note, you can skip this variable if you
+  run this DAG in a Composer environment.
 """
 from __future__ import annotations
 
@@ -24,23 +29,23 @@ import logging
 import os
 from datetime import datetime
 
-from googleapiclient import discovery
-
 from airflow import models
 from airflow.decorators import task
 from airflow.models import Connection
 from airflow.operators.bash import BashOperator
 from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
-from airflow.providers.google.cloud.operators.cloud_sql import (
-    CloudSQLCreateInstanceDatabaseOperator,
-    CloudSQLCreateInstanceOperator,
-    CloudSQLDeleteInstanceOperator,
+from airflow.providers.google.cloud.hooks.compute import ComputeEngineHook
+from airflow.providers.google.cloud.hooks.compute_ssh import ComputeEngineSSHHook
+from airflow.providers.google.cloud.operators.compute import (
+    ComputeEngineDeleteInstanceOperator,
+    ComputeEngineInsertInstanceOperator,
 )
 from airflow.providers.google.cloud.operators.gcs import (
     GCSCreateBucketOperator,
     GCSDeleteBucketOperator,
 )
 from airflow.providers.google.cloud.transfers.postgres_to_gcs import PostgresToGCSOperator
+from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.settings import Session
 from airflow.utils.trigger_rule import TriggerRule
 
@@ -48,40 +53,90 @@ DAG_ID = "example_postgres_to_gcs"
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "example-project")
 
-CLOUD_SQL_INSTANCE = f"cloud-sql-{DAG_ID}-{ENV_ID}".replace("_", "-")
-CLOUD_SQL_INSTANCE_CREATION_BODY = {
-    "name": CLOUD_SQL_INSTANCE,
-    "settings": {
-        "tier": "db-custom-1-3840",
-        "dataDiskSizeGb": 30,
-        "ipConfiguration": {
-            "ipv4Enabled": True,
-            "requireSsl": False,
-            # Consider specifying your network mask
-            # for allowing requests only from the trusted sources, not from anywhere
-            "authorizedNetworks": [
-                {"value": "0.0.0.0/0"},
-            ],
-        },
-        "pricingPlan": "PER_USE",
-    },
-    "databaseVersion": "POSTGRES_15",
-    "region": "us-central1",
-}
-DB_NAME = f"{DAG_ID}-{ENV_ID}-db".replace("-", "_")
+REGION = "europe-west2"
+ZONE = REGION + "-a"
+NETWORK = "default"
+
+DB_NAME = "testdb"
 DB_PORT = 5432
-DB_CREATE_BODY = {"instance": CLOUD_SQL_INSTANCE, "name": DB_NAME, "project": PROJECT_ID}
 DB_USER_NAME = "demo_user"
 DB_USER_PASSWORD = "demo_password"
+
+SHORT_MACHINE_TYPE_NAME = "n1-standard-1"
+DB_INSTANCE_NAME = f"instance-{DAG_ID}-{ENV_ID}".replace("_", "-")
+GCE_INSTANCE_BODY = {
+    "name": DB_INSTANCE_NAME,
+    "machine_type": f"zones/{ZONE}/machineTypes/{SHORT_MACHINE_TYPE_NAME}",
+    "disks": [
+        {
+            "boot": True,
+            "device_name": DB_INSTANCE_NAME,
+            "initialize_params": {
+                "disk_size_gb": "10",
+                "disk_type": f"zones/{ZONE}/diskTypes/pd-balanced",
+                "source_image": "projects/debian-cloud/global/images/debian-11-bullseye-v20220621",
+            },
+        }
+    ],
+    "network_interfaces": [
+        {
+            "access_configs": [{"name": "External NAT", "network_tier": "PREMIUM"}],
+            "stack_type": "IPV4_ONLY",
+            "subnetwork": f"regions/{REGION}/subnetworks/default",
+        }
+    ],
+}
+DELETE_PERSISTENT_DISK = f"""
+if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
+ gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
+fi;
+
+gcloud compute disks delete {DB_INSTANCE_NAME} --project={PROJECT_ID} --zone={ZONE} --quiet
+"""
+
+SETUP_POSTGRES = f"""
+sudo apt update &&
+sudo apt install -y docker.io &&
+sudo docker run -d -p {DB_PORT}:{DB_PORT} --name {DB_NAME} \
+    -e POSTGRES_USER={DB_USER_NAME} \
+    -e POSTGRES_PASSWORD={DB_USER_PASSWORD} \
+    -e POSTGRES_DB={DB_NAME} \
+    postgres
+"""
+
+FIREWALL_RULE_NAME = f"allow-http-{DB_PORT}"
+CREATE_FIREWALL_RULE = f"""
+if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
+ gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
+fi;
+
+gcloud compute firewall-rules create {FIREWALL_RULE_NAME} \
+  --project={PROJECT_ID} \
+  --direction=INGRESS \
+  --priority=100 \
+  --network={NETWORK} \
+  --action=ALLOW \
+  --rules=tcp:{DB_PORT} \
+  --source-ranges=0.0.0.0/0
+"""
+DELETE_FIREWALL_RULE = f"""
+if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \
+ gcloud auth activate-service-account --key-file=$AIRFLOW__API__GOOGLE_KEY_PATH; \
+fi;
+
+gcloud compute firewall-rules delete {FIREWALL_RULE_NAME} --project={PROJECT_ID} --quiet
+"""
+
 CONNECTION_ID = f"postgres_{DAG_ID}_{ENV_ID}".replace("-", "_")
 
-BUCKET_NAME = f"{DAG_ID}_{ENV_ID}_bucket"
+BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 FILE_NAME = "result.json"
 
 SQL_TABLE = "test_table"
 SQL_CREATE = f"CREATE TABLE IF NOT EXISTS {SQL_TABLE} (col_1 INT, col_2 VARCHAR(8))"
 SQL_INSERT = f"INSERT INTO {SQL_TABLE} (col_1, col_2) VALUES (1, 'one'), (2, 'two')"
 SQL_SELECT = f"SELECT * FROM {SQL_TABLE}"
+
 
 log = logging.getLogger(__name__)
 
@@ -93,42 +148,39 @@ with models.DAG(
     catchup=False,
     tags=["example", "postgres", "gcs"],
 ) as dag:
-    create_cloud_sql_instance = CloudSQLCreateInstanceOperator(
-        task_id="create_cloud_sql_instance",
+    create_instance = ComputeEngineInsertInstanceOperator(
+        task_id="create_instance",
         project_id=PROJECT_ID,
-        instance=CLOUD_SQL_INSTANCE,
-        body=CLOUD_SQL_INSTANCE_CREATION_BODY,
+        zone=ZONE,
+        body=GCE_INSTANCE_BODY,
     )
 
-    create_database = CloudSQLCreateInstanceDatabaseOperator(
-        task_id="create_database", body=DB_CREATE_BODY, instance=CLOUD_SQL_INSTANCE
+    create_firewall_rule = BashOperator(
+        task_id="create_firewall_rule",
+        bash_command=CREATE_FIREWALL_RULE,
+    )
+
+    setup_postgres = SSHOperator(
+        task_id="setup_postgres",
+        ssh_hook=ComputeEngineSSHHook(
+            user="username",
+            instance_name=DB_INSTANCE_NAME,
+            zone=ZONE,
+            project_id=PROJECT_ID,
+            use_oslogin=False,
+            use_iap_tunnel=False,
+            cmd_timeout=180,
+        ),
+        command=SETUP_POSTGRES,
+        retries=2,
+        retry_delay=30,
     )
 
     @task
-    def create_user() -> None:
-        with discovery.build("sqladmin", "v1beta4") as service:
-            request = service.users().insert(
-                project=PROJECT_ID,
-                instance=CLOUD_SQL_INSTANCE,
-                body={
-                    "name": DB_USER_NAME,
-                    "password": DB_USER_PASSWORD,
-                },
-            )
-            request.execute()
-
-    create_user_task = create_user()
-
-    @task
-    def get_public_ip() -> str | None:
-        with discovery.build("sqladmin", "v1beta4") as service:
-            request = service.connect().get(
-                project=PROJECT_ID, instance=CLOUD_SQL_INSTANCE, fields="ipAddresses"
-            )
-            response = request.execute()
-            for ip_item in response.get("ipAddresses", []):
-                if ip_item["type"] == "PRIMARY":
-                    return ip_item["ipAddress"]
+    def get_public_ip() -> str:
+        hook = ComputeEngineHook()
+        address = hook.get_instance_address(resource_id=DB_INSTANCE_NAME, zone=ZONE, project_id=PROJECT_ID)
+        return address
 
     get_public_ip_task = get_public_ip()
 
@@ -183,13 +235,6 @@ with models.DAG(
     )
     # [END howto_operator_postgres_to_gcs]
 
-    delete_cloud_sql_instance = CloudSQLDeleteInstanceOperator(
-        task_id="delete_cloud_sql_instance",
-        project_id=PROJECT_ID,
-        instance=CLOUD_SQL_INSTANCE,
-        trigger_rule=TriggerRule.ALL_DONE,
-    )
-
     delete_postgres_connection = BashOperator(
         task_id="delete_postgres_connection",
         bash_command=f"airflow connections delete {CONNECTION_ID}",
@@ -202,17 +247,42 @@ with models.DAG(
         trigger_rule=TriggerRule.ALL_DONE,
     )
 
+    delete_instance = ComputeEngineDeleteInstanceOperator(
+        task_id="delete_instance",
+        resource_id=DB_INSTANCE_NAME,
+        zone=ZONE,
+        project_id=PROJECT_ID,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_firewall_rule = BashOperator(
+        task_id="delete_firewall_rule",
+        bash_command=DELETE_FIREWALL_RULE,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
+    delete_persistent_disk = BashOperator(
+        task_id="delete_persistent_disk",
+        bash_command=DELETE_PERSISTENT_DISK,
+        trigger_rule=TriggerRule.ALL_DONE,
+    )
+
     # TEST SETUP
-    create_cloud_sql_instance >> [create_database, create_user_task, get_public_ip_task]
-    [create_user_task, get_public_ip_task] >> setup_postgres_connection_task
-    create_database >> setup_postgres_connection_task >> create_sql_table >> insert_data
+    create_instance >> setup_postgres
+    (create_instance >> get_public_ip_task >> setup_postgres_connection_task)
+    (
+        [setup_postgres, setup_postgres_connection_task, create_firewall_rule]
+        >> create_sql_table
+        >> insert_data
+    )
     (
         [insert_data, create_bucket]
         # TEST BODY
         >> get_data
         # TEST TEARDOWN
-        >> [delete_cloud_sql_instance, delete_postgres_connection, delete_bucket]
+        >> [delete_instance, delete_bucket, delete_postgres_connection, delete_firewall_rule]
     )
+    delete_instance >> delete_persistent_disk
 
     from tests.system.utils.watcher import watcher
 


### PR DESCRIPTION
System tests for `PostgresToGCSOperator` and `MySQLToGCSOperator` now use databases deployed in GCE instances rather than CloudSQL. The reason for this is CloudSQL recommended connection method is using cloud proxy but `PostgresToGCSOperator` and `MySQLToGCSOperator` expect connection to a raw database by IP.  The new implementation is cleaner and eliminates workaround with authorized network masks for the `PostgresToGCSOperator`.