### PR TITLE
Fix CloudRunExecuteJobOperator in deferrable mode

### DIFF
--- a/airflow/providers/google/cloud/operators/cloud_run.py
+++ b/airflow/providers/google/cloud/operators/cloud_run.py
@@ -321,10 +321,10 @@ class CloudRunExecuteJobOperator(GoogleCloudBaseOperator):
     def execute_complete(self, context: Context, event: dict):
         status = event["status"]
 
-        if status == RunJobStatus.TIMEOUT:
+        if status == RunJobStatus.TIMEOUT.value:
             raise AirflowException("Operation timed out")
 
-        if status == RunJobStatus.FAIL:
+        if status == RunJobStatus.FAIL.value:
             error_code = event["operation_error_code"]
             error_message = event["operation_error_message"]
             raise AirflowException(

--- a/airflow/providers/google/cloud/triggers/cloud_run.py
+++ b/airflow/providers/google/cloud/triggers/cloud_run.py
@@ -102,21 +102,21 @@ class CloudRunJobFinishedTrigger(BaseTrigger):
         while timeout is None or timeout > 0:
             operation: operations_pb2.Operation = await hook.get_operation(self.operation_name)
             if operation.done:
-                # An operation can only have one of those two combinations: if it is succeeded, then
-                # the response field will be populated, else, then the error field will be.
-                if operation.response is not None:
+                # An operation can only have one of those two combinations: if it is failed, then
+                # the error field will be populated, else, then the response field will be.
+                if operation.error.SerializeToString():
                     yield TriggerEvent(
                         {
-                            "status": RunJobStatus.SUCCESS,
+                            "status": RunJobStatus.FAIL.value,
+                            "operation_error_code": operation.error.code,
+                            "operation_error_message": operation.error.message,
                             "job_name": self.job_name,
                         }
                     )
                 else:
                     yield TriggerEvent(
                         {
-                            "status": RunJobStatus.FAIL,
-                            "operation_error_code": operation.error.code,
-                            "operation_error_message": operation.error.message,
+                            "status": RunJobStatus.SUCCESS.value,
                             "job_name": self.job_name,
                         }
                     )

--- a/tests/providers/google/cloud/operators/test_cloud_run.py
+++ b/tests/providers/google/cloud/operators/test_cloud_run.py
@@ -166,7 +166,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, deferrable=True
         )
 
-        event = {"status": RunJobStatus.TIMEOUT, "job_name": JOB_NAME}
+        event = {"status": RunJobStatus.TIMEOUT.value, "job_name": JOB_NAME}
 
         with pytest.raises(AirflowException) as e:
             operator.execute_complete(mock.MagicMock(), event)
@@ -183,7 +183,7 @@ class TestCloudRunExecuteJobOperator:
         error_message = "error message"
 
         event = {
-            "status": RunJobStatus.FAIL,
+            "status": RunJobStatus.FAIL.value,
             "operation_error_code": error_code,
             "operation_error_message": error_message,
             "job_name": JOB_NAME,
@@ -204,7 +204,7 @@ class TestCloudRunExecuteJobOperator:
             task_id=TASK_ID, project_id=PROJECT_ID, region=REGION, job_name=JOB_NAME, deferrable=True
         )
 
-        event = {"status": RunJobStatus.SUCCESS, "job_name": JOB_NAME}
+        event = {"status": RunJobStatus.SUCCESS.value, "job_name": JOB_NAME}
 
         result = operator.execute_complete(mock.MagicMock(), event)
         assert result["name"] == JOB_NAME

--- a/tests/providers/google/cloud/triggers/test_cloud_run.py
+++ b/tests/providers/google/cloud/triggers/test_cloud_run.py
@@ -20,13 +20,16 @@ from __future__ import annotations
 from unittest import mock
 
 import pytest
+from google.protobuf.any_pb2 import Any
+from google.rpc.status_pb2 import Status
 
-from airflow.exceptions import AirflowException
 from airflow.providers.google.cloud.triggers.cloud_run import CloudRunJobFinishedTrigger, RunJobStatus
 from airflow.triggers.base import TriggerEvent
 
 OPERATION_NAME = "operation"
 JOB_NAME = "jobName"
+ERROR_CODE = 13
+ERROR_MESSAGE = "Some message"
 PROJECT_ID = "projectId"
 LOCATION = "us-central1"
 GCP_CONNECTION_ID = "gcp_connection_id"
@@ -73,20 +76,21 @@ class TestCloudBatchJobFinishedTrigger:
         Tests the CloudRunJobFinishedTrigger fires once the job execution reaches a successful state.
         """
 
-        done = True
-        name = "name"
-        error_code = 10
-        error_message = "message"
+        async def _mock_operation(name):
+            operation = mock.MagicMock()
+            operation.done = True
+            operation.name = "name"
+            operation.error = Any()
+            operation.error.ParseFromString(b"")
+            return operation
 
-        mock_hook.return_value.get_operation.return_value = self._mock_operation(
-            done, name, error_code, error_message
-        )
+        mock_hook.return_value.get_operation = _mock_operation
         generator = trigger.run()
         actual = await generator.asend(None)  # type:ignore[attr-defined]
         assert (
             TriggerEvent(
                 {
-                    "status": RunJobStatus.SUCCESS,
+                    "status": RunJobStatus.SUCCESS.value,
                     "job_name": JOB_NAME,
                 }
             )
@@ -102,18 +106,28 @@ class TestCloudBatchJobFinishedTrigger:
         Tests the CloudRunJobFinishedTrigger raises an exception once the job execution fails.
         """
 
-        done = False
-        name = "name"
-        error_code = 10
-        error_message = "message"
+        async def _mock_operation(name):
+            operation = mock.MagicMock()
+            operation.done = True
+            operation.name = "name"
+            operation.error = Status(code=13, message="Some message")
+            return operation
 
-        mock_hook.return_value.get_operation.return_value = self._mock_operation(
-            done, name, error_code, error_message
-        )
+        mock_hook.return_value.get_operation = _mock_operation
         generator = trigger.run()
 
-        with pytest.raises(expected_exception=AirflowException):
-            await generator.asend(None)  # type:ignore[attr-defined]
+        actual = await generator.asend(None)  # type:ignore[attr-defined]
+        assert (
+            TriggerEvent(
+                {
+                    "status": RunJobStatus.FAIL.value,
+                    "operation_error_code": ERROR_CODE,
+                    "operation_error_message": ERROR_MESSAGE,
+                    "job_name": JOB_NAME,
+                }
+            )
+            == actual
+        )
 
     @pytest.mark.asyncio
     @mock.patch("airflow.providers.google.cloud.triggers.cloud_run.CloudRunAsyncHook")
@@ -144,12 +158,3 @@ class TestCloudBatchJobFinishedTrigger:
             )
             == actual
         )
-
-    async def _mock_operation(self, done, name, error_code, error_message):
-        operation = mock.MagicMock()
-        operation.done = done
-        operation.name = name
-        operation.error = mock.MagicMock()
-        operation.error.message = error_message
-        operation.error.code = error_code
-        return operation


### PR DESCRIPTION
Fix CloudRunExecuteJobOperator not able to retrieve the Cloud Run job status in deferrable mode

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
